### PR TITLE
Remove PDF download and fix search credit deduction

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -40,18 +40,16 @@ export default function Index() {
     try {
       const { data, normalized } = await performSearch(q);
 
-      if (normalized.hasMeaningfulData) {
-        try {
-          await consumeSearchCredit(user.uid, 1);
-        } catch (creditError) {
-          if (isFirestorePermissionDenied(creditError)) {
-            console.warn(
-              "Skipping credit consumption due to permission error.",
-              creditError,
-            );
-          } else {
-            throw creditError;
-          }
+      try {
+        await consumeSearchCredit(user.uid, 1);
+      } catch (creditError) {
+        if (isFirestorePermissionDenied(creditError)) {
+          console.warn(
+            "Skipping credit consumption due to permission error.",
+            creditError,
+          );
+        } else {
+          throw creditError;
         }
       }
 

--- a/client/pages/SearchResults.tsx
+++ b/client/pages/SearchResults.tsx
@@ -142,14 +142,14 @@ export default function SearchResults() {
                   </span>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  onClick={onSearch}
-                  disabled={loading}
-                  className="h-10"
-                >
-                  {loading ? "Searching…" : "Search"}
-                </Button>
-              </div>
+                  <Button
+                    onClick={onSearch}
+                    disabled={loading}
+                    className="h-10"
+                  >
+                    {loading ? "Searching…" : "Search"}
+                  </Button>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Purpose
The user requested two key fixes: remove the PDF download functionality for search results and resolve an issue where search balance credits were not being properly deducted after successful searches.

## Code changes
- **Removed PDF download feature**: Eliminated the download button, PDF generation logic, and related dependencies (html2canvas, jsPDF) from SearchResults component
- **Fixed credit deduction logic**: Modified credit consumption to occur for all searches rather than only when meaningful data is detected, ensuring credits are properly deducted across all search pages (Index, Databases, SearchResults)
- **Simplified error handling**: Maintained permission error handling for Firestore while removing conditional credit consumption based on search results
- **Cleaned up unused code**: Removed PDF-related constants, refs, and state variables that are no longer needed

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/36ed1a4258614b5897c30f92e8a857ee/cosmos-realm)

👀 [Preview Link](https://36ed1a4258614b5897c30f92e8a857ee-cosmos-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>36ed1a4258614b5897c30f92e8a857ee</projectId>-->
<!--<branchName>cosmos-realm</branchName>-->